### PR TITLE
use default distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: required
 language: java
 jdk:


### PR DESCRIPTION
Use default distribution which is `xenial` as trusty is deprecated for languages other than **android**