### PR TITLE
RestPoller configuration and new Interval implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file, which loose
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-
+- Extended RestPoller to include custom PollInterval implementation and introduced FibonacciPollWithStartAndMax class
 
 # [17.102.1] - 2025-02-26
 ### Changed

--- a/framework-utilities/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/http/FibonacciPollWithStartAndMax.java
+++ b/framework-utilities/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/http/FibonacciPollWithStartAndMax.java
@@ -1,0 +1,40 @@
+package uk.gov.justice.services.test.utils.core.http;
+
+import org.awaitility.pollinterval.FibonacciPollInterval;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Fibonacci style Poll interval class with startInterval and MaxInterval.
+ */
+public class FibonacciPollWithStartAndMax extends FibonacciPollInterval {
+    public static final Duration DEFAULT_MAX_INTERVAL_1S = Duration.ofSeconds(1);
+    public static final Duration DEFAULT_START_INTERVAL = Duration.ofMillis(1);
+    private final Duration startInterval;
+    private final Duration maxInterval;
+
+
+    public FibonacciPollWithStartAndMax(Duration startInterval, Duration maxInterval) {
+        super(1, TimeUnit.MILLISECONDS);
+        this.startInterval = startInterval;
+        this.maxInterval = maxInterval;
+    }
+
+    public FibonacciPollWithStartAndMax(Duration startInterval) {
+        this(startInterval, DEFAULT_MAX_INTERVAL_1S);
+    }
+
+    public FibonacciPollWithStartAndMax() {
+        this(DEFAULT_START_INTERVAL, DEFAULT_MAX_INTERVAL_1S);
+    }
+
+    @Override
+    public Duration next(int pollCount, Duration previousDuration) {
+        Duration duration = startInterval.multipliedBy(fibonacci(pollCount));
+        if (maxInterval.compareTo(duration) < 0) {
+            return maxInterval;
+        }
+        return duration;
+    }
+}

--- a/framework-utilities/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/http/RestPoller.java
+++ b/framework-utilities/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/http/RestPoller.java
@@ -162,8 +162,8 @@ public class RestPoller {
         this.await = await()
                 .with()
                 .pollInterval((pollCount, previousDuration) ->
-                        Duration.ofMillis((long) (exponentialStartIntervalMs * Math.pow(2, pollCount - 1))))
-                .timeout(10, TimeUnit.SECONDS);
+                        Duration.ofMillis((long) ((double) exponentialStartIntervalMs * Math.pow(2, pollCount - 1))))
+                .timeout(10, SECONDS);
     }
 
     /**

--- a/framework-utilities/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/http/RestPoller.java
+++ b/framework-utilities/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/http/RestPoller.java
@@ -137,7 +137,9 @@ public class RestPoller {
     RestPoller(final RestClient restClient, final RequestParams requestParams) {
         this.requestParams = requestParams;
         this.restClient = restClient;
-        this.await = await().with().pollInterval(1, SECONDS).with().timeout(10, SECONDS);
+        this.await = await().with()
+                .pollInterval(1, SECONDS)
+                .with().timeout(10, SECONDS);
     }
 
     /**

--- a/framework-utilities/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/http/RestPoller.java
+++ b/framework-utilities/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/http/RestPoller.java
@@ -136,7 +136,7 @@ public class RestPoller {
     private Optional<Matcher<ResponseData>> ignoredResponseMatcher = empty();
 
     /**
-     * Sends envelope to the next component setting system user id.
+     * Instantiates a new rest poller
      *
      * @deprecated use RestPoller(RestClient, requestParams, pollInterval, timeout),
      * default polling values defined here are not viable for most of usages
@@ -164,11 +164,10 @@ public class RestPoller {
     /**
      * Instantiates a new rest poller
      *
-     * @deprecated use poll(RestClient, requestParams, pollInterval, timeout),
-     * default polling values defined here are not viable for most of usages
-     *
      * @param requestParams request parameters
      * @return this
+     * @deprecated use poll(RestClient, requestParams, pollInterval, timeout),
+     * default polling values defined here are not viable for most of usages
      */
     @Deprecated
     public static RestPoller poll(final RequestParams requestParams) {
@@ -178,11 +177,10 @@ public class RestPoller {
     /**
      * Instantiates a new rest poller
      *
-     * @deprecated use poll(RestClient, requestParams, pollInterval, timeout),
-     * default polling values defined here are not viable for most of usages
-     *
      * @param requestParamsBuilder request parameters builder
      * @return this
+     * @deprecated use poll(RestClient, requestParams, pollInterval, timeout),
+     * default polling values defined here are not viable for most of usages
      */
     @Deprecated
     public static RestPoller poll(final RequestParamsBuilder requestParamsBuilder) {
@@ -259,12 +257,12 @@ public class RestPoller {
 
     /**
      * Overrides the delay between polls. If not specified a default of 1 second is used.
+     *
      * @param pollInterval PollInterval Strategy, please look {@link FibonacciPollWithStartAndMax}
-     * @param timeout max amount of time to poll
-     * @return
+     * @return this
      */
-    public RestPoller pollInterval(PollInterval pollInterval, Duration timeout) {
-        this.await = this.await.with().pollInterval(pollInterval).timeout(timeout);
+    public RestPoller pollInterval(PollInterval pollInterval) {
+        this.await = this.await.with().pollInterval(pollInterval);
         return this;
     }
 

--- a/framework-utilities/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/http/RestPoller.java
+++ b/framework-utilities/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/http/RestPoller.java
@@ -30,9 +30,9 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 /**
  * Client for polling a rest endpoint and matching the response against the specified Matcher.
- * <p>
+ *
  * To Use:
- * <p>
+ *
  * Poll until the response has specified number of events with required json payload:
  * <pre><blockquote>
  *
@@ -60,12 +60,12 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
  *      ;
  *
  * </blockquote></pre>
- * <p>
+ *
  * The call is configured using <code>RequestParams</code>. This object is most easily created using
  * a <code>RequestParamsBuilder</code> which takes a url and media type and will supply all other
  * required parameters with defaults. Overriding these defaults is done in the usual builder pattern
  * way.
- * <p>
+ *
  * Poll until the response has specified substring in the payload:
  * <pre><blockquote>
  *
@@ -90,7 +90,7 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
  *      ;
  *
  * </blockquote></pre>
- * <p>
+ *
  * Poll ignoring certain response status, until the response has specified number of events with
  * required data:
  * <pre><blockquote>
@@ -261,7 +261,7 @@ public class RestPoller {
 
     /**
      * Poll at most <code>timeout</code> before throwing a timeout exception.
-     * <p>
+     *
      * Overrides the default timeout period. If not specified a default of 10 seconds is used.
      *
      * @param timeout the timeout

--- a/framework-utilities/test-utils/test-utils-core/src/test/java/uk/gov/justice/services/test/utils/core/http/FibonacciPollWithStartAndMaxTest.java
+++ b/framework-utilities/test-utils/test-utils-core/src/test/java/uk/gov/justice/services/test/utils/core/http/FibonacciPollWithStartAndMaxTest.java
@@ -1,0 +1,41 @@
+package uk.gov.justice.services.test.utils.core.http;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.stream.LongStream;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+class FibonacciPollWithStartAndMaxTest {
+
+    @Test
+    void shouldPollFibonacciMinMaxWithDefaults() {
+        FibonacciPollWithStartAndMax pollIntervalWithMax = new FibonacciPollWithStartAndMax();
+
+        long[] result = LongStream.range(1, 9).map(i -> pollIntervalWithMax.next((int) i, Duration.ZERO).toMillis())
+                .toArray();
+        assertArrayEquals(new long[]{1, 1, 2, 3, 5, 8, 13, 21}, result);
+
+    }
+
+    @Test
+    public void shouldPollFibonacciMinMax() {
+        FibonacciPollWithStartAndMax pollIntervalWithMax = new FibonacciPollWithStartAndMax(Duration.ofMillis(10), Duration.ofMillis(100));
+
+        long[] result = LongStream.range(1, 9).map(i -> pollIntervalWithMax.next((int) i, Duration.ZERO).toMillis())
+                .toArray();
+
+        assertArrayEquals(new long[]{10, 10, 20, 30, 50, 80, 100, 100}, result);
+    }
+
+    @Test
+    public void shouldPollFibonacciMaxIsSmallerThanMin() {
+        FibonacciPollWithStartAndMax pollIntervalWithMax = new FibonacciPollWithStartAndMax(Duration.ofMillis(100), Duration.ofMillis(10));
+
+        long[] result = LongStream.range(1, 4).map(i -> pollIntervalWithMax.next((int) i, Duration.ZERO).toMillis())
+                .toArray();
+
+        assertArrayEquals(new long[]{10, 10, 10}, result);
+    }
+}

--- a/framework-utilities/test-utils/test-utils-core/src/test/java/uk/gov/justice/services/test/utils/core/http/RestPollerTest.java
+++ b/framework-utilities/test-utils/test-utils-core/src/test/java/uk/gov/justice/services/test/utils/core/http/RestPollerTest.java
@@ -212,7 +212,7 @@ public class RestPollerTest {
     }
 
     @Test
-    public void shouldPollUsingExponentialBackoffStrategyUntilExpectedResponse() {
+    void shouldPollUsingExponentialBackoffStrategyUntilExpectedResponse() {
         final String payloadValue = "expected-value";
         when(response.readEntity(String.class))
                 .thenReturn("{}")
@@ -235,7 +235,7 @@ public class RestPollerTest {
     }
 
     @Test
-    public void shouldPollUsingFibonacciStrategyUntilExpectedResponse() {
+    void shouldPollUsingFibonacciStrategyUntilExpectedResponse() {
         final String payloadValue = "expected-value";
         when(response.readEntity(String.class))
                 .thenReturn("{}")


### PR DESCRIPTION
[PEG-1650](https://tools.hmcts.net/jira/browse/PEG-1650) - 
Added support for Fibonacci polling strategy to RestPoller

Added two new Interval class(FibonacciPollWithStartAndMax) to support RestPoller class:  
  The Fibonacci strategy follows the sequence: 1ms, 1ms, 2ms, 3ms, 5ms and so on 
